### PR TITLE
fix: error "TypeError: Cannot read property 'start' of undefined"

### DIFF
--- a/packages/unist-util-to-list-of-char/index.js
+++ b/packages/unist-util-to-list-of-char/index.js
@@ -1,4 +1,5 @@
 const visit = require('unist-util-visit');
+const generated = require('unist-util-generated');
 
 function valueOf(node) {
   if (!node) return null;
@@ -16,6 +17,7 @@ function toList(root, _test, _callback) {
   function getTree(tree) {
     const list = [];
     function visitor(node) {
+      if (generated(node)) return;
       const value = valueOf(node);
       if (typeof value !== 'string') return;
       const { line, column, offset } = node.position.start;

--- a/packages/unist-util-to-list-of-char/package.json
+++ b/packages/unist-util-to-list-of-char/package.json
@@ -20,6 +20,7 @@
     "url": "git+https://github.com/laysent/remark-lint-plugins.git"
   },
   "dependencies": {
+    "unist-util-generated": "^1.1.6",
     "unist-util-visit": "^1.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6507,6 +6507,11 @@ unist-util-generated@^1.1.0:
   version "1.1.3"
   resolved "http://registry.npm.taobao.org/unist-util-generated/download/unist-util-generated-1.1.3.tgz#ca650470aef2fbcc5fe54c465bc26b41ca109e2b"
 
+unist-util-generated@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
+  integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
+
 unist-util-is@^2.1.2:
   version "2.1.2"
   resolved "http://registry.npm.taobao.org/unist-util-is/download/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"


### PR DESCRIPTION
`node.position` is optional if the node is generated.
This change aims to fix the following potential error by the package [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated).

```
TypeError: Cannot read property 'start' of undefined
    at visitor (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/index.js:21:54)
    at overload (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit/index.js:27:12)
    at one (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:34:25)
    at all (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:57:16)
    at one (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:42:28)
    at all (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:57:16)
    at one (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:42:28)
    at visitParents (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit-parents/index.js:26:3)
    at visit (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/node_modules/unist-util-visit/index.js:22:3)
    at getTree (/home/analyzer_runner/remark_lint/node_modules/unist-util-to-list-of-char/index.js:40:5)
```

Please see below about the actual use of `unist-util-generated`:
<https://github.com/remarkjs/remark-lint/blob/00a6312656d471c491faf6db7eeef46253aeb72c/packages/remark-lint-blockquote-indentation/index.js#L71>